### PR TITLE
Disallows curly spacing for expression

### DIFF
--- a/packages/eslint-config/.eslintrc
+++ b/packages/eslint-config/.eslintrc
@@ -5,6 +5,11 @@
         // being JSON at some point, and I don't want to make big changes now.
         "comma-dangle": 0,
         // we support node 4
-        "prefer-destructuring": 0
+        "prefer-destructuring": 0,
+        // Disallow jsx curly spacing for expressions
+        // Although the disallow is the default bahavior it covers the attributes
+        // not expressions
+        "react/jsx-curly-spacing": [2, {"children": true}]
+
     }
 }


### PR DESCRIPTION
Though the default configuration for the [react/jsx-curly-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/v7.11.0/docs/rules/jsx-curly-spacing.md) rule is to disallow spacing inside curly braces but I've found that it checks for attributes, not expressions.

There is an older [comment](https://github.com/yannickcr/eslint-plugin-react/issues/1528#issuecomment-345848089) in this regard and I've observed that the behavior still holds true.

This PR enables checking of the default rule behavior for the expression.

How enabling this checking will impact the coding style can be found [here](https://github.com/yannickcr/eslint-plugin-react/blob/v7.11.0/docs/rules/jsx-curly-spacing.md#never).

